### PR TITLE
Fix NotFoundException in duplicate finder

### DIFF
--- a/lib/BackgroundJob/CleanUpDB.php
+++ b/lib/BackgroundJob/CleanUpDB.php
@@ -66,6 +66,7 @@ class CleanUpDB extends TimedJob
             try {
                 $this->folderService->getNodeByFileInfo($fileInfo);
             } catch (NotFoundException $e) {
+                $this->logger->warning('File not found: ' . $fileInfo->getPath());
                 $this->logger->info('FileInfo ' . $fileInfo->getPath() . ' will be deleted');
                 $this->fileInfoService->delete($fileInfo);
             }

--- a/lib/Listener/FileInfoListener.php
+++ b/lib/Listener/FileInfoListener.php
@@ -43,6 +43,8 @@ class FileInfoListener implements IEventListener
                     $this->fileInfoService->calculateHashes($fileInfo, $event->getUserID(), false);
                 }
             }
+        } catch (\OCP\Files\NotFoundException $e) {
+            $this->logger->warning('File not found: ' . $e->getMessage());
         } catch (\Throwable $e) {
             $this->logger->error('Failed to handle NewFileInfoEvent.', ['exception' => $e]);
         }


### PR DESCRIPTION
Fixes #56

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eldertek/duplicatefinder/issues/56?shareId=ce07a2c8-1dcb-420a-affd-a6ccfcd43bb8).