### PR TITLE
Fix SQL error with PostgreSQL as DB

### DIFF
--- a/lib/Db/FileDuplicateMapper.php
+++ b/lib/Db/FileDuplicateMapper.php
@@ -26,8 +26,8 @@ class FileDuplicateMapper extends EQBMapper
         $qb->select('*')
             ->from($this->getTableName())
             ->where(
-                $qb->expr()->eq('hash', $qb->createNamedParameter($hash)),
-                $qb->expr()->eq('type', $qb->createNamedParameter($type))
+                $qb->expr()->eq('hash', $qb->createNamedParameter($hash, IQueryBuilder::PARAM_STR)),
+                $qb->expr()->eq('type', $qb->createNamedParameter($type, IQueryBuilder::PARAM_STR))
             );
         return $this->findEntity($qb);
     }
@@ -83,7 +83,7 @@ class FileDuplicateMapper extends EQBMapper
         try {
             $qb->update($this->getTableName())
                 ->set('acknowledged', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
-                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash)))
+                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash, IQueryBuilder::PARAM_STR)))
                 ->execute();
 
             return true;
@@ -107,7 +107,7 @@ class FileDuplicateMapper extends EQBMapper
         try {
             $qb->update($this->getTableName())
                 ->set('acknowledged', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL))
-                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash)))
+                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash, IQueryBuilder::PARAM_STR)))
                 ->execute();
 
             return true;
@@ -160,7 +160,7 @@ class FileDuplicateMapper extends EQBMapper
         try {
             $qb->update($this->getTableName())
                 ->set('suppressed', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
-                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash)))
+                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash, IQueryBuilder::PARAM_STR)))
                 ->execute();
 
             return true;
@@ -183,7 +183,7 @@ class FileDuplicateMapper extends EQBMapper
         try {
             $qb->update($this->getTableName())
                 ->set('suppressed', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL))
-                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash)))
+                ->where($qb->expr()->eq('hash', $qb->createNamedParameter($hash, IQueryBuilder::PARAM_STR)))
                 ->execute();
 
             return true;


### PR DESCRIPTION
Fixes #73

Modify `lib/Db/FileDuplicateMapper.php` to handle byte sequences for UTF8 encoding and ensure proper parameter binding in SQL queries.

* Update `find` method to use `IQueryBuilder::PARAM_STR` for `hash` and `type` parameters.
* Modify `markAsAcknowledged`, `unmarkAcknowledged`, `suppress`, and `unsuppress` methods to use `IQueryBuilder::PARAM_STR` for `hash` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eldertek/duplicatefinder/issues/73?shareId=bcc007ee-90f0-4492-b911-c3653878d095).