### PR TITLE
Improve duplicate search root configuration

### DIFF
--- a/lib/Command/FindDuplicates.php
+++ b/lib/Command/FindDuplicates.php
@@ -3,6 +3,7 @@
 namespace OCA\DuplicateFinder\Command;
 
 use OCA\DuplicateFinder\AppInfo\Application;
+use OCA\DuplicateFinder\Service\ConfigService;
 use OCA\DuplicateFinder\Service\FileDuplicateService;
 use OCA\DuplicateFinder\Service\FileInfoService;
 use OCA\DuplicateFinder\Utils\CMDUtils;
@@ -58,6 +59,11 @@ class FindDuplicates extends Command
     private $output;
 
     /**
+     * @var ConfigService The config service instance.
+     */
+    private $configService;
+
+    /**
      * FindDuplicates constructor.
      *
      * @param IUserManager $userManager The user manager instance.
@@ -66,6 +72,7 @@ class FindDuplicates extends Command
      * @param FileInfoService $fileInfoService The file info service instance.
      * @param FileDuplicateService $fileDuplicateService The file duplicate service instance.
      * @param LoggerInterface $logger The logger instance.
+     * @param ConfigService $configService The config service instance.
      */
     public function __construct(
         IUserManager $userManager,
@@ -73,7 +80,8 @@ class FindDuplicates extends Command
         IDBConnection $connection,
         FileInfoService $fileInfoService,
         FileDuplicateService $fileDuplicateService,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        ConfigService $configService
     ) {
         parent::__construct('duplicates:find-all');
         $this->userManager = $userManager;
@@ -82,6 +90,7 @@ class FindDuplicates extends Command
         $this->fileInfoService = $fileInfoService;
         $this->fileDuplicateService = $fileDuplicateService;
         $this->logger = $logger;
+        $this->configService = $configService;
     }
 
     /**
@@ -214,11 +223,13 @@ class FindDuplicates extends Command
             return false; // Continue scanning
         };
 
+        $rootPath = $this->configService->getDuplicateSearchRoot();
+
         if (empty($paths)) {
-            $this->fileInfoService->scanFiles($user, null, $callback, $this->output);
+            $this->fileInfoService->scanFiles($user, $rootPath, $callback, $this->output);
         } else {
             foreach ($paths as $path) {
-                $this->fileInfoService->scanFiles($user, $path, $callback, $this->output);
+                $this->fileInfoService->scanFiles($user, $rootPath . DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR), $callback, $this->output);
             }
         }
 

--- a/lib/Controller/SettingsApiController.php
+++ b/lib/Controller/SettingsApiController.php
@@ -33,7 +33,8 @@ class SettingsApiController extends AbstractAPIController
             'backgroundjob_interval_cleanup' => $this->configService->getCleanupJobInterval(),
             'disable_filesystem_events' => $this->configService->areFilesytemEventsDisabled(),
             'ignore_mounted_files' => $this->configService->areMountedFilesIgnored(),
-            'installed_version' => $this->configService->getInstalledVersion()
+            'installed_version' => $this->configService->getInstalledVersion(),
+            'duplicate_search_root' => $this->configService->getDuplicateSearchRoot()
         ];
     }
 
@@ -52,7 +53,8 @@ class SettingsApiController extends AbstractAPIController
             'backgroundjob_interval_find' => 'setFindJobInterval',
             'backgroundjob_interval_cleanup' => 'setCleanupJobInterval',
             'disable_filesystem_events' => 'setFilesytemEventsDisabled',
-            'ignore_mounted_files' => 'setMountedFilesIgnored'
+            'ignore_mounted_files' => 'setMountedFilesIgnored',
+            'duplicate_search_root' => 'setDuplicateSearchRoot'
         ];
 
         if (!array_key_exists($key, $configKeys)) {
@@ -72,5 +74,25 @@ class SettingsApiController extends AbstractAPIController
         }
 
         return new DataResponse(['status' => 'success', 'data' => $this->getConfigArray()]);
+    }
+
+    public function saveDuplicateSearchRoot(string $root): DataResponse
+    {
+        try {
+            $this->configService->setDuplicateSearchRoot($root);
+            return new DataResponse(['status' => 'success']);
+        } catch (\Exception $e) {
+            return new DataResponse(['status' => 'error', 'message' => $e->getMessage()]);
+        }
+    }
+
+    public function getDuplicateSearchRoot(): DataResponse
+    {
+        try {
+            $root = $this->configService->getDuplicateSearchRoot();
+            return new DataResponse(['status' => 'success', 'data' => $root]);
+        } catch (\Exception $e) {
+            return new DataResponse(['status' => 'error', 'message' => $e->getMessage()]);
+        }
     }
 }

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -104,4 +104,14 @@ class ConfigService
     {
         $this->setBoolVal('ignore_mounted_files', $value);
     }
+
+    public function getDuplicateSearchRoot(): string
+    {
+        return $this->config->getAppValue(Application::ID, 'duplicate_search_root', '/');
+    }
+
+    public function setDuplicateSearchRoot(string $value): void
+    {
+        $this->config->setAppValue(Application::ID, 'duplicate_search_root', $value);
+    }
 }

--- a/lib/Service/FileInfoService.php
+++ b/lib/Service/FileInfoService.php
@@ -42,6 +42,7 @@ class FileInfoService
     private $lockingProvider;
     private $rootFolder;
     private $connection;
+    private $configService;
 
     public function __construct(
         FileInfoMapper $mapper,
@@ -53,7 +54,8 @@ class FileInfoService
         ScannerUtil $scannerUtil,
         ILockingProvider $lockingProvider,
         IRootFolder $rootFolder,
-        IDBConnection $connection
+        IDBConnection $connection,
+        ConfigService $configService
     ) {
         $this->mapper = $mapper;
         $this->eventDispatcher = $eventDispatcher;
@@ -65,6 +67,7 @@ class FileInfoService
         $this->lockingProvider = $lockingProvider;
         $this->rootFolder = $rootFolder;
         $this->connection = $connection;
+        $this->configService = $configService;
     }
 
     /**
@@ -262,7 +265,7 @@ class FileInfoService
         ?bool $isShared = false
     ): void {
         $userFolder = $this->folderService->getUserFolder($user);
-        $scanPath = $userFolder->getPath();
+        $scanPath = $this->configService->getDuplicateSearchRoot();
         if (!is_null($path) && !$isShared) {
             $scanPath .= DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR);
             if (!$userFolder->nodeExists(ltrim($path, DIRECTORY_SEPARATOR))) {
@@ -300,7 +303,7 @@ class FileInfoService
         }
     }
 
-    private function handleLockedFile(string $path, ?OutputInterface $output): void
+    private void handleLockedFile(string $path, ?OutputInterface $output): void
     {
         try {
             // Get the file node
@@ -374,7 +377,7 @@ class FileInfoService
 
         try {
             $path = $this->shareService->hasAccessRight(
-                $this->folderService->getNodeByFileInfo($fileInfo, $user),
+                $this->.folderService->getNodeByFileInfo($fileInfo, $user),
                 $user
             );
             return !is_null($path);

--- a/src/Settings.vue
+++ b/src/Settings.vue
@@ -36,6 +36,13 @@
         @update:value="saveSettings('backgroundjob_interval_find', settings.backgroundjob_interval_find)"></NcTextField>
     </NcSettingsSection>
 
+    <NcSettingsSection :name="t('duplicatefinder', 'Duplicate Search Root Directory')"
+      :description="t('duplicatefinder', 'The root directory for the duplicate search.')"
+      :limit-width="true">
+      <NcTextField :value.sync="settings.duplicate_search_root"
+        @update:value="saveSettings('duplicate_search_root', settings.duplicate_search_root)"></NcTextField>
+    </NcSettingsSection>
+
     <NcSettingsSection :name="t('duplicatefinder', 'Advanced settings (be cautious)')" 
       :description="t('duplicatefinder', 'These settings are for advanced users only. If you are not sure what you are doing, please do not change them.')"
       :limit-width="true">
@@ -119,4 +126,3 @@ export default {
 }
 
 </style>
-


### PR DESCRIPTION
Fixes #81

Add the ability to configure the root directory for the duplicate search.

* **ConfigService**: Add methods `getDuplicateSearchRoot` and `setDuplicateSearchRoot` to manage the root directory for the duplicate search.
* **FindDuplicates**: Modify the `execute` method to use the configured root directory from `ConfigService` for the duplicate search.
* **FileInfoService**: Modify the `scanFiles` method to use the configured root directory from `ConfigService` for scanning files.
* **SettingsApiController**: Add methods `saveDuplicateSearchRoot` and `getDuplicateSearchRoot` to manage the root directory for the duplicate search.
* **Settings.vue**: Add a new section in the settings UI to allow users to configure the root directory for the duplicate search.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eldertek/duplicatefinder/issues/81?shareId=d692ece2-e2be-4d21-957c-c60b37495318).