### PR TITLE
Fix Nextcloud v33 compatibility: Update QueryBuilder API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.5 - TBD
+### Fixed
+- Fixed compatibility with Nextcloud v33 by updating QueryBuilder API calls
+- Replaced deprecated `execute()` with `executeQuery()` for SELECT statements
+- Replaced deprecated `execute()` with `executeStatement()` for INSERT/UPDATE/DELETE statements
+
 ## 1.7.4 - 2025-01-11
 ### Critical Security Fix
 - **CRITICAL**: Fixed automatic file deletion bug that could cause permanent data loss (Fix [#153](https://github.com/eldertek/duplicatefinder/issues/153))

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -56,7 +56,7 @@
     <donation>https://patreon.com/eldertek</donation>
       
     <dependencies>
-        <nextcloud min-version="28" max-version="31"/>
+        <nextcloud min-version="28" max-version="33"/>
     </dependencies>
 
     <background-jobs>

--- a/lib/Db/EQBMapper.php
+++ b/lib/Db/EQBMapper.php
@@ -63,7 +63,7 @@ abstract class EQBMapper extends QBMapper
             ->where(
                 $qb->expr()->eq('id', $qb->createNamedParameter($entity->getId(), $idType))
             );
-            $qb = $qb->execute();
+            $qb = $qb->executeQuery();
 
             $values = [];
             if (!is_int($qb)) {
@@ -101,7 +101,7 @@ abstract class EQBMapper extends QBMapper
             ->where(
                 $qb->expr()->eq('id', $qb->createNamedParameter($entity->getId(), $idType))
             );
-            $qb = $qb->execute();
+            $qb = $qb->executeStatement();
             if (!is_int($qb)) {
                 $qb->closeCursor();
             }
@@ -135,7 +135,7 @@ abstract class EQBMapper extends QBMapper
                         $qb->expr()->eq('rid', $qb->createNamedParameter($key, IQueryBuilder::PARAM_INT))
                     );
                 }
-                $qb = $qb->execute();
+                $qb = $qb->executeStatement();
                 if (!is_int($qb)) {
                     $qb->closeCursor();
                 }
@@ -159,7 +159,7 @@ abstract class EQBMapper extends QBMapper
         ->where(
             $qb->expr()->eq($field, $qb->createNamedParameter($value, $type))
         );
-        $qb = $qb->execute();
+        $qb = $qb->executeQuery();
         if (!is_int($qb)) {
             if (!$this->db->getDatabasePlatform() instanceof SqlitePlatform
               && !$this->db->getDatabasePlatform() instanceof PostgreSQL94Platform
@@ -180,9 +180,9 @@ abstract class EQBMapper extends QBMapper
     {
         $qb = $this->db->getQueryBuilder();
         if (is_null($table)) {
-            $qb = $qb->delete($this->getTableName())->execute();
+            $qb = $qb->delete($this->getTableName())->executeStatement();
         } else {
-            $qb = $qb->delete($table)->execute();
+            $qb = $qb->delete($table)->executeStatement();
         }
         if (!is_int($qb)) {
             $qb->closeCursor();

--- a/lib/Db/ProjectMapper.php
+++ b/lib/Db/ProjectMapper.php
@@ -79,7 +79,7 @@ class ProjectMapper extends QBMapper
                    'project_id' => $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_INT),
                    'folder_path' => $qb->createNamedParameter($folderPath, IQueryBuilder::PARAM_STR),
                ])
-               ->execute();
+               ->executeStatement();
         }
     }
 
@@ -98,7 +98,7 @@ class ProjectMapper extends QBMapper
                $qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_INT))
            );
 
-        $result = $qb->execute();
+        $result = $qb->executeQuery();
         $folders = [];
         while ($row = $result->fetch()) {
             $folders[] = $row['folder_path'];
@@ -120,7 +120,7 @@ class ProjectMapper extends QBMapper
            ->where(
                $qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_INT))
            )
-           ->execute();
+           ->executeStatement();
     }
 
     /**
@@ -148,7 +148,7 @@ class ProjectMapper extends QBMapper
                $qb->expr()->eq('duplicate_id', $qb->createNamedParameter($duplicateId, IQueryBuilder::PARAM_INT))
            );
 
-        $result = $qb->execute();
+        $result = $qb->executeQuery();
         $exists = $result->fetch();
         $result->closeCursor();
 
@@ -165,7 +165,7 @@ class ProjectMapper extends QBMapper
                    'project_id' => $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_INT),
                    'duplicate_id' => $qb->createNamedParameter($duplicateId, IQueryBuilder::PARAM_INT),
                ])
-               ->execute();
+               ->executeStatement();
         } else {
             $this->logger->debug('Duplicate already associated with project, skipping', [
                 'app' => 'duplicatefinder',
@@ -195,7 +195,7 @@ class ProjectMapper extends QBMapper
                $qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_INT))
            );
 
-        $result = $qb->execute();
+        $result = $qb->executeQuery();
         $duplicateIds = [];
         while ($row = $result->fetch()) {
             $duplicateIds[] = (int)$row['duplicate_id'];
@@ -230,7 +230,7 @@ class ProjectMapper extends QBMapper
                $qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_INT))
            );
 
-        $count = $qb->execute();
+        $count = $qb->executeStatement();
 
         $this->logger->debug('Removed duplicates for project', [
             'app' => 'duplicatefinder',
@@ -253,6 +253,6 @@ class ProjectMapper extends QBMapper
            ->where(
                $qb->expr()->eq('id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_INT))
            )
-           ->execute();
+           ->executeStatement();
     }
 }

--- a/lib/Migration/RepairNullTypes.php
+++ b/lib/Migration/RepairNullTypes.php
@@ -46,7 +46,7 @@ class RepairNullTypes implements IRepairStep
            ->from('duplicatefinder_dups')
            ->where($qb->expr()->isNull('type'));
 
-        $result = $qb->execute();
+        $result = $qb->executeQuery();
         $count = (int)$result->fetchOne();
         $result->closeCursor();
 
@@ -59,7 +59,7 @@ class RepairNullTypes implements IRepairStep
                     ->set('type', $updateQb->createNamedParameter('file_hash'))
                     ->where($updateQb->expr()->isNull('type'));
 
-            $updated = $updateQb->execute();
+            $updated = $updateQb->executeStatement();
 
             $output->info("Fixed {$updated} records with NULL type values.");
             $this->logger->info("Fixed {$updated} records with NULL type values in duplicatefinder_dups table.");


### PR DESCRIPTION
Replace deprecated execute() method with:
- executeQuery() for SELECT statements
- executeStatement() for INSERT/UPDATE/DELETE statements

This fixes the 'Call to undefined method QueryBuilder::execute()' error when enabling duplicatefinder in Nextcloud v33.

Changes:
- Updated lib/Db/EQBMapper.php (5 occurrences)
- Updated lib/Db/ProjectMapper.php (8 occurrences)
- Updated lib/Migration/RepairNullTypes.php (2 occurrences)
- Extended Nextcloud version support to v33 in appinfo/info.xml
- Updated CHANGELOG.md