### PR TITLE
fix: Add compatibility with Nextcloud 32 and 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.7.5 - Unreleased
+## 1.7.5 - 2026-05-25
 ### Fixed
 - Fixed checkbox array error in bulk delete by keeping `NcCheckboxRadioSwitch` boolean checkboxes out of checkbox-group mode (Fix [#145](https://github.com/eldertek/duplicatefinder/issues/145))
 - Return a `FILE_LOCKED` API error and a clear notification when a locked file cannot be deleted (Fix [#161](https://github.com/eldertek/duplicatefinder/issues/161))
-- Fixed compatibility with Nextcloud 33 by replacing deprecated QueryBuilder `execute()` calls and extending the supported Nextcloud range to 33 (Fix [#168](https://github.com/eldertek/duplicatefinder/issues/168), [#166](https://github.com/eldertek/duplicatefinder/issues/166), PR [#169](https://github.com/eldertek/duplicatefinder/pull/169))
+- Fixed compatibility with Nextcloud 32 and 33 by replacing deprecated QueryBuilder `execute()` calls, replacing deprecated `fetch()`/`fetchAll()` with `fetchAssociative()`/`fetchAllAssociative()`, replacing deprecated `PostgreSQL94Platform` with `PostgreSQLPlatform`, and extending the supported Nextcloud range to 33 (Fix [#168](https://github.com/eldertek/duplicatefinder/issues/168), [#166](https://github.com/eldertek/duplicatefinder/issues/166), [#171](https://github.com/eldertek/duplicatefinder/issues/171), PR [#169](https://github.com/eldertek/duplicatefinder/pull/169))
 - Fixed project migration installation when legacy duplicate tables are missing (Fix [#157](https://github.com/eldertek/duplicatefinder/issues/157))
 
 ## 1.7.4 - 2025-01-11

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@
 * 📊 **Aperçu & Simulation** - Visualisez ce qui serait supprimé avant d'agir
 * 💼 **Traitement en Arrière-plan** - Tâches automatisées de recherche de doublons
 ]]></description>
-    <version>1.7.4</version>
+    <version>1.7.5</version>
     <author>André Théo LAURET</author>
 
     <namespace>DuplicateFinder</namespace>

--- a/lib/Db/EQBMapper.php
+++ b/lib/Db/EQBMapper.php
@@ -2,7 +2,7 @@
 
 namespace OCA\DuplicateFinder\Db;
 
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\QBMapper;
@@ -67,7 +67,7 @@ abstract class EQBMapper extends QBMapper
 
             $values = [];
             if (!is_int($qb)) {
-                foreach ($qb->fetchAll() as $row) {
+                foreach ($qb->fetchAllAssociative() as $row) {
                     $values[$row['rid']] = $row['value'];
                 }
                 unset($row);
@@ -162,11 +162,11 @@ abstract class EQBMapper extends QBMapper
         $qb = $qb->executeQuery();
         if (!is_int($qb)) {
             if (!$this->db->getDatabasePlatform() instanceof SqlitePlatform
-              && !$this->db->getDatabasePlatform() instanceof PostgreSQL94Platform
+              && !$this->db->getDatabasePlatform() instanceof PostgreSQLPlatform
             ) {
                 $count = $qb->rowCount();
             } else {
-                $count = count($qb->fetchAll());
+                $count = count($qb->fetchAllAssociative());
             }
             $qb->closeCursor();
 

--- a/lib/Db/ExcludedFolderMapper.php
+++ b/lib/Db/ExcludedFolderMapper.php
@@ -116,7 +116,7 @@ class ExcludedFolderMapper extends QBMapper
            ->andWhere($qb->expr()->eq('folder_path', $qb->createNamedParameter($path)));
 
         $result = $qb->executeQuery();
-        $exists = $result->fetch();
+        $exists = $result->fetchAssociative();
         $result->closeCursor();
 
         $this->logger->debug('Folder exclusion check result', [

--- a/lib/Db/FileDuplicateMapper.php
+++ b/lib/Db/FileDuplicateMapper.php
@@ -182,7 +182,7 @@ class FileDuplicateMapper extends EQBMapper
 
         // Execute the query and fetch the result
         $result = $qb->executeQuery();
-        $row = $result->fetch();
+        $row = $result->fetchAssociative();
         $result->closeCursor();
 
         // Return the count result as an integer
@@ -314,7 +314,7 @@ class FileDuplicateMapper extends EQBMapper
         $result = $qb->executeQuery();
         $duplicates = [];
 
-        while ($row = $result->fetch()) {
+        while ($row = $result->fetchAssociative()) {
             $duplicates[] = $row;
         }
         $result->closeCursor();
@@ -344,7 +344,7 @@ class FileDuplicateMapper extends EQBMapper
         $result = $qb->executeQuery();
         $files = [];
 
-        while ($row = $result->fetch()) {
+        while ($row = $result->fetchAssociative()) {
             $files[] = [
                 'path' => $row['path'],
                 'size' => $row['size'] ?? 0,

--- a/lib/Db/ProjectMapper.php
+++ b/lib/Db/ProjectMapper.php
@@ -100,7 +100,7 @@ class ProjectMapper extends QBMapper
 
         $result = $qb->executeQuery();
         $folders = [];
-        while ($row = $result->fetch()) {
+        while ($row = $result->fetchAssociative()) {
             $folders[] = $row['folder_path'];
         }
         $result->closeCursor();
@@ -149,7 +149,7 @@ class ProjectMapper extends QBMapper
            );
 
         $result = $qb->executeQuery();
-        $exists = $result->fetch();
+        $exists = $result->fetchAssociative();
         $result->closeCursor();
 
         if (!$exists) {
@@ -197,7 +197,7 @@ class ProjectMapper extends QBMapper
 
         $result = $qb->executeQuery();
         $duplicateIds = [];
-        while ($row = $result->fetch()) {
+        while ($row = $result->fetchAssociative()) {
             $duplicateIds[] = (int)$row['duplicate_id'];
         }
         $result->closeCursor();

--- a/lib/Migration/RepairFileInfos.php
+++ b/lib/Migration/RepairFileInfos.php
@@ -106,7 +106,7 @@ class RepairFileInfos implements IRepairStep
         if (!$result) {
             return [];
         }
-        $rows = $result->fetchAll();
+        $rows = $result->fetchAllAssociative();
         $result->closeCursor();
 
         return $rows;


### PR DESCRIPTION
## Summary

Fixes #171 — Duplicate Finder was not compatible with Nextcloud v32 and v33 due to deprecated and removed APIs.

## Changes

### Core fix (NC 33 — `IQueryBuilder::execute()` removed)
The removal of `IQueryBuilder::execute()` in NC 33 was already handled in the codebase (all DB mappers use `executeQuery()`/`executeStatement()`). This PR finalises that work as release 1.7.5.

### Additional deprecation fixes
- **`lib/Db/EQBMapper.php`**: Replace `Doctrine\DBAL\Platforms\PostgreSQL94Platform` (deprecated in DBAL 3.3, still present in DBAL 3.10 used by NC 32/33) with `PostgreSQLPlatform`. Also replace `fetchAll()` with `fetchAllAssociative()`.
- **`lib/Db/FileDuplicateMapper.php`**: Replace 3 `IResult::fetch()` calls with `fetchAssociative()` (soft-deprecated in NC 33).
- **`lib/Db/ExcludedFolderMapper.php`**: Replace `IResult::fetch()` with `fetchAssociative()`.
- **`lib/Db/ProjectMapper.php`**: Replace 3 `IResult::fetch()` calls with `fetchAssociative()`.
- **`lib/Migration/RepairFileInfos.php`**: Replace `IResult::fetchAll()` with `fetchAllAssociative()`.

### Version & Docs
- Bump version to 1.7.5 in `appinfo/info.xml`
- Update `CHANGELOG.md` to mark 1.7.5 as released