### PR TITLE
fix: stop re-inserting a row on hash/type collision in getOrCreate()

### DIFF
--- a/lib/Db/FileDuplicateMapper.php
+++ b/lib/Db/FileDuplicateMapper.php
@@ -35,6 +35,26 @@ class FileDuplicateMapper extends EQBMapper
     }
 
     /**
+     * Like find(), but tolerant of pre-existing hash/type collisions:
+     * caps the query at one row db-side so it never throws
+     * MultipleObjectsReturnedException.
+     */
+    public function findFirst(string $hash, string $type = 'file_hash'): FileDuplicate
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where(
+                $qb->expr()->eq('hash', $qb->createNamedParameter($hash)),
+                $qb->expr()->eq('type', $qb->createNamedParameter($type))
+            )
+            ->orderBy('id', 'ASC')
+            ->setMaxResults(1);
+
+        return $this->findEntity($qb);
+    }
+
+    /**
      * @param string|null $user
      * @param int|null $limit
      * @param int|null $offset

--- a/lib/Service/FileDuplicateService.php
+++ b/lib/Service/FileDuplicateService.php
@@ -8,6 +8,7 @@ use OCA\DuplicateFinder\Db\FileDuplicateMapper;
 use OCA\DuplicateFinder\Db\FileInfo;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\Lock\ILockingProvider;
 use Psr\Log\LoggerInterface;
 
@@ -198,6 +199,12 @@ class FileDuplicateService
     {
         try {
             $fileDuplicate = $this->mapper->find($hash, $type);
+        } catch (MultipleObjectsReturnedException $e) {
+            // Several rows already exist for this hash/type (e.g. many
+            // empty files sharing the same hash) — reuse the oldest one
+            // instead of inserting yet another row, which would only grow
+            // the collision and make this exception recur on every scan.
+            $fileDuplicate = $this->mapper->findFirst($hash, $type);
         } catch (\Exception $e) {
             if (!($e instanceof DoesNotExistException)) {
                 $this->logger->error('A unknown exception occured', ['app' => Application::ID, 'exception' => $e]);


### PR DESCRIPTION
Fixes #178

## Problem

`FileDuplicateService::getOrCreate()` caught any exception generically (including `MultipleObjectsReturnedException`), logged it as an "unknown exception", and always fell through to inserting a brand new row. Once a hash/type collision existed for any reason, every subsequent scan re-triggered the same exception and added yet another row — the collision (and the log spam) only grew over time and never self-healed, even after a full `occ duplicates:clear` + rescan.

On our instance this produced ~2000 "A unknown exception occured" log entries and one hash/type pair (the SHA-256 of an empty file) alone reached 1721 rows in `duplicatefinder_dups`.

## Fix

- `FileDuplicateMapper::findFirst()` — same query as `find()`, but `ORDER BY id ASC LIMIT 1` db-side, so it can never throw `MultipleObjectsReturnedException`.
- `FileDuplicateService::getOrCreate()` — catches `MultipleObjectsReturnedException` explicitly (before the generic `\Exception` catch) and reuses the oldest existing row via `findFirst()` instead of inserting a new one. Behavior for the genuine "not found" and other error cases is unchanged.

## Testing

Applied this fix locally (Nextcloud 33.0.4 / PHP 8.3.6 / PostgreSQL), cleared the table, ran a full `occ duplicates:find-all` rescan on ~100k files: row count went from ~88729 (mostly collision self-amplification) down to 172 genuine duplicates, with no new `MultipleObjectsReturnedException`/"unknown exception" logged since.

`php -l` clean on both changed files.